### PR TITLE
Feat Offset - format date to follow DDMMYY

### DIFF
--- a/lib/offset.rb
+++ b/lib/offset.rb
@@ -12,5 +12,7 @@ class Offset
     last_4_dig = squared.to_s[-4..-1].to_i
   end
 
-  # def add_to_keys
+  def format_date(unformatted_date)
+    unformatted_date = (Time.new).strftime("%d%m%y").to_i
+  end
 end

--- a/spec/offset_spec.rb
+++ b/spec/offset_spec.rb
@@ -2,12 +2,14 @@ require './lib/enigma'
 require './lib/key_generator'
 require './lib/offset'
 require 'date'
-require_relative './spec_helper'
+require 'time'
+# require_relative './spec_helper'
 
 RSpec.describe Offset do
   before :each do
     @enigma = Enigma.new
-    @offset = Offset.new(110622)
+    @offset = Offset.new("110622")
+    @time = Time.new
   end
 
   it "exists" do
@@ -25,11 +27,12 @@ RSpec.describe Offset do
   it "returns the last 4 digits of its squared numeric date" do
     expect(@offset.last_four).to eq(6884)
   end
-end
 
-#   xit "can create a date in DDMMYY format if no date is given" do
-#
-#   end
+
+  it "can create a date in DDMMYY format if no date is given" do
+    expect(@offset.format_date("06-12-2022")).to eq(120622)
+  end
+end
 #
 #   # it "can be added to keys to create final shifts" do
 #   #


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe):
## Problem/feature
_What problem are you trying to solve?_

If an Offset isn't given a date in DDMMYY format it should have a way to reformat it that way

## Solution
_How did you solve the problem?_

Used #strftime method to take an unformatted date and return it in the DDMMYY format

## Other changes (e.g. bug fixes, UI tweaks, small refactors)
## Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary